### PR TITLE
created addRelatedSkills function

### DIFF
--- a/server/generated/graphqlEden.ts
+++ b/server/generated/graphqlEden.ts
@@ -133,7 +133,7 @@ export type Mutation = {
   addProject?: Maybe<Project>;
   addProjectRole?: Maybe<ProjectRole>;
   addProjectTeamMember?: Maybe<ProjectTeamMember>;
-  addRelatedSkills?: Maybe<Array<Maybe<Skill>>>;
+  addRelatedSkills?: Maybe<Skill>;
   addSkill?: Maybe<Skill>;
   addSkills?: Maybe<Array<Maybe<Skill>>>;
   addSkillsToMember?: Maybe<Member>;

--- a/server/graphql/resolvers/skills/index.ts
+++ b/server/graphql/resolvers/skills/index.ts
@@ -1,4 +1,8 @@
+import relatedSkills from "./objectResolvers/relatedSkills";
+
 export default {
   // Object Resolvers
-  Skill: {},
+  Skill: {
+    relatedSkills: relatedSkills
+  },
 };

--- a/server/graphql/resolvers/skills/mutation/addRelatedSkills.ts
+++ b/server/graphql/resolvers/skills/mutation/addRelatedSkills.ts
@@ -1,0 +1,72 @@
+import { Skill, AddRelatedSkillsInput } from "../../../../generated";
+import { Skills } from "../../../../models/skillModel";
+import { ApolloError } from "apollo-server-express";
+
+const addRelatedSkills = async (
+  parent: any,
+  args: { request: AddRelatedSkillsInput },
+  context: any,
+  info: any,
+): Promise<Skill> => {
+  const { skillID, relatedSkillIDs } = args.request;
+
+  console.log("Mutation > relatedSkills > args.request = ", args.request);
+
+  if (!skillID) throw new ApolloError("You need to specify the id of the skill");
+
+  let skillData: Skill;
+  let relatedSkillsData: Skill[] = [];
+
+  skillData = await Skills.findOne({ _id: skillID });
+
+
+  relatedSkillsData = await Skills.find({ _id: relatedSkillIDs });
+
+  console.log("relatedSkilldata", relatedSkillsData);
+  let result;
+
+  try {
+    for (let i = 0; i < relatedSkillsData.length; i++) {
+
+      const skillsArrayToSaveRelatedSkills = skillData.relatedSkills ? skillData.relatedSkills : [];
+      const currentRelatedSkill = relatedSkillsData[i];
+
+      if (!skillsArrayToSaveRelatedSkills.includes(currentRelatedSkill._id as Skill)) {
+        skillsArrayToSaveRelatedSkills.push(currentRelatedSkill._id as Skill);
+      }
+
+      result = await Skills.findOneAndUpdate(
+        { _id: skillData._id },
+        {
+          $set: {
+            relatedSkills: skillsArrayToSaveRelatedSkills,
+          },
+        },
+        { new: true },
+      );
+      
+      const relatedSkilledArray = relatedSkillsData[i].relatedSkills ? relatedSkillsData[i].relatedSkills: <any>[];
+      if (!relatedSkilledArray.includes(skillData._id as Skill)) {
+         relatedSkilledArray.push(skillData._id);
+      }
+
+      await Skills.findOneAndUpdate(
+        { _id: relatedSkillsData[i]._id },
+        {
+          $set: {
+            relatedSkills: relatedSkilledArray,
+          },
+        },
+        { new: true },
+      );
+    }
+  } catch (err: any) {
+    throw new ApolloError(err.message, err.extensions?.code || "DATABASE_FIND_TWEET_ERROR", {
+      component: "tSkillMutation > addRelatedSkills",
+    });
+  }
+  console.log("skillData ", skillData);
+  return skillData;
+};
+
+export default addRelatedSkills;

--- a/server/graphql/resolvers/skills/mutation/index.ts
+++ b/server/graphql/resolvers/skills/mutation/index.ts
@@ -1,11 +1,13 @@
 import addSkill from "./addSkill";
 import addSkills from "./addSkills";
 import approveOrRejectSkills from "./approveOrRejectSkills";
+import addRelatedSkills from "./addRelatedSkills"
 // import createSkills from "./createSkills";
 
 export default {
   // Mutations
   addSkill,
   addSkills,
-  approveOrRejectSkills
+  approveOrRejectSkills,
+  addRelatedSkills
 };

--- a/server/graphql/resolvers/skills/objectResolvers/relatedSkills.ts
+++ b/server/graphql/resolvers/skills/objectResolvers/relatedSkills.ts
@@ -1,0 +1,23 @@
+import { Skill } from "../../../../generated";
+import { Skills } from "../../../../models/skillModel";
+import { ApolloError } from "apollo-server-express";
+
+const relatedSkills = async (
+  parent: Skill,
+  args: any,
+  context: any,
+  info: any,
+): Promise<Skill[]> => {
+  try {
+    const relatedSkills = parent.relatedSkills;
+    let relatedSkillsData = await Skills.find({ _id: relatedSkills });
+    return relatedSkillsData;
+  } catch (err: any) {
+    throw new ApolloError(err.message, err.extensions?.code || "DATABASE_SEARCH_ERROR", {
+      component: "userResolver > skills",
+      user: context.req.user?._id,
+    });
+  }
+};
+
+export default relatedSkills;

--- a/server/graphql/schema/skill/mutation.ts
+++ b/server/graphql/schema/skill/mutation.ts
@@ -8,7 +8,7 @@ export default gql`
 
     approveOrRejectSkills(request: [approveOrRejectSkillInput]): [Skill]
 
-    addRelatedSkills(request: addRelatedSkillsInput): [Skill]
+    addRelatedSkills(request: addRelatedSkillsInput): Skill
     #  ------------ Skills -----------
   }
 `;

--- a/server/models/skillModel.ts
+++ b/server/models/skillModel.ts
@@ -11,7 +11,7 @@ const skillSchema = mongoose.Schema({
   skillCategoriesID: [mongoose.Schema.Types.ObjectId],
   skillSubCategoriesID: [mongoose.Schema.Types.ObjectId],
 
-  relatedSkillsID: [mongoose.Schema.Types.ObjectId],
+  relatedSkills: [mongoose.Schema.Types.ObjectId],
 
   lightcastID: String,
 


### PR DESCRIPTION
Created a function to add the related skills. I also created the object resolvers for relatedSkills and I rename the relatedSkillsID field of the Skills model to relatedSkills. This was done because the Skill type schema was declared as such and the easiest option was changing the Skill model name instead of changing it in multiple places.