### PR TITLE
Remove request object from waitingToApproveSkills query

### DIFF
--- a/server/generated/graphqlEden.ts
+++ b/server/generated/graphqlEden.ts
@@ -618,11 +618,6 @@ export type QuerySearchSkillsAutocompleteArgs = {
   request?: InputMaybe<SkillsAutocompleteInput>;
 };
 
-
-export type QueryWaitingToAproveSkillsArgs = {
-  request?: InputMaybe<FindSkillsInput>;
-};
-
 export type RoleTemplate = {
   __typename?: 'RoleTemplate';
   _id?: Maybe<Scalars['ID']>;

--- a/server/graphql/schema/skill/query.ts
+++ b/server/graphql/schema/skill/query.ts
@@ -12,7 +12,7 @@ export default gql`
       limit: Int
     ): FindSkillsCursorOutput
 
-    waitingToAproveSkills(request: findSkillsInput): [Skill]
+    waitingToAproveSkills: [Skill]
 
     # TODO: Merge this into findSkills
     searchSkillsAutocomplete(request: skillsAutocompleteInput): [Skill]


### PR DESCRIPTION
Remove request object from the query schema. The function does not accept any input data, it just returns all skills with a state of WAITING. 